### PR TITLE
[TASK] Patch #6, Allow resize in the element/link browser dialog RTE's

### DIFF
--- a/Resources/Public/Stylesheet/PagetreeResizable.css
+++ b/Resources/Public/Stylesheet/PagetreeResizable.css
@@ -30,10 +30,13 @@
 }
 
 @media (max-width: 639px) {
-	.element-browser-main .ui-resizable-handle {
-		display: none;
-	}
-	.element-browser .element-browser-main .element-browser-main-sidebar {
-		width: auto!important;
-	}
+    .element-browser .element-browser-main .element-browser-main-sidebar {
+        width: auto;
+    }
+    #wizard-link-browse .element-browser-main .ui-resizable-handle {
+        display: none;
+    }
+    #wizard-link-browse .element-browser .element-browser-main .element-browser-main-sidebar {
+        width: auto !important;
+    }
 }


### PR DESCRIPTION
In the RTE's modal box, the selector took mobile styling making the right column hardly visible.