### PR TITLE
Add extension-key to composer extra section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,10 @@
     "psr-4": {
       "Wazum\\PagetreeResizable\\": "Classes"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "pagetree_resizable"
+    }
   }
 }


### PR DESCRIPTION
Specifying the extension key will be mandatory in future versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)